### PR TITLE
Add .NET Framework Shopify app skeleton

### DIFF
--- a/Biz/ProductBiz.cs
+++ b/Biz/ProductBiz.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using ShopifyApp.Dac;
+using ShopifyApp.Info;
+
+namespace ShopifyApp.Biz
+{
+    public class ProductBiz
+    {
+        private readonly ProductDac _productDac;
+
+        public ProductBiz()
+        {
+            _productDac = new ProductDac();
+        }
+
+        public List<ProductInfo> GetProducts()
+        {
+            return _productDac.GetProducts();
+        }
+    }
+}

--- a/Dac/ProductDac.cs
+++ b/Dac/ProductDac.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Newtonsoft.Json;
+using ShopifyApp.Info;
+
+namespace ShopifyApp.Dac
+{
+    public class ProductDac
+    {
+        private readonly string _shopDomain = "your-store.myshopify.com"; // TODO: change
+        private readonly string _accessToken = "shpat_your_token"; // TODO: change
+
+        private class ProductRoot { public List<Product> products { get; set; } }
+        private class Product { public long id { get; set; } public string title { get; set; } public Variant[] variants { get; set; } }
+        private class Variant { public decimal price { get; set; } }
+
+        public List<ProductInfo> GetProducts()
+        {
+            using (var client = new WebClient())
+            {
+                client.Headers.Add("X-Shopify-Access-Token", _accessToken);
+                var url = $"https://{_shopDomain}/admin/api/2023-04/products.json";
+                var json = client.DownloadString(url);
+                var data = JsonConvert.DeserializeObject<ProductRoot>(json);
+                return data.products.Select(p => new ProductInfo
+                {
+                    Id = p.id,
+                    Title = p.title,
+                    Price = p.variants != null && p.variants.Length > 0 ? p.variants[0].price : 0m
+                }).ToList();
+            }
+        }
+    }
+}

--- a/Info/ProductInfo.cs
+++ b/Info/ProductInfo.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ShopifyApp.Info
+{
+    public class ProductInfo
+    {
+        public long Id { get; set; }
+        public string Title { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,25 @@
+using System;
+using ShopifyApp.Biz;
+
+namespace ShopifyApp
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var biz = new ProductBiz();
+            try
+            {
+                var products = biz.GetProducts();
+                foreach (var p in products)
+                {
+                    Console.WriteLine($"{p.Id}: {p.Title} - ${p.Price}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Failed to fetch products: " + ex.Message);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# shopifyApp
+# ShopifyApp
+
+This sample demonstrates a .NET Framework 4.7.2 console application using a layered architecture to retrieve products from Shopify.
+
+## Layers
+- **Info**: model classes
+- **Dac**: data access for Shopify APIs
+- **Biz**: business logic using the Dac layer
+
+## Build
+Run `msbuild ShopifyApp.csproj` in a machine with Visual Studio Build Tools or the full .NET Framework SDK installed.
+
+## Run
+After building, execute the compiled `ShopifyApp.exe`. It will attempt to fetch products from Shopify and print their titles.
+
+Replace the placeholder Shopify credentials in `Dac/ProductDac.cs` with your own before running.
+

--- a/ShopifyApp.csproj
+++ b/ShopifyApp.csproj
@@ -1,0 +1,22 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <RootNamespace>ShopifyApp</RootNamespace>
+    <AssemblyName>ShopifyApp</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Info\ProductInfo.cs" />
+    <Compile Include="Dac\ProductDac.cs" />
+    <Compile Include="Biz\ProductBiz.cs" />
+  </ItemGroup>
+</Project>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
## Summary
- replace the Node.js example with a C# .NET Framework 4.7.2 console app
- implement Info, Dac, and Biz layers
- add basic Shopify API integration logic
- document build/run steps

## Testing
- `msbuild ShopifyApp.csproj` *(fails: msbuild not installed)*