### PR TITLE
Switch to .NET Framework layered solution with Shopify integration

### DIFF
--- a/Biz/Biz.csproj
+++ b/Biz/Biz.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <ProjectReference Include="..\Dac\Dac.csproj" />
+  </ItemGroup>
+</Project>

--- a/Biz/ProductBiz.cs
+++ b/Biz/ProductBiz.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Info;
+using Dac;
+
+namespace Biz
+{
+    public class ProductBiz
+    {
+        private readonly ProductDac _dac = new ProductDac();
+
+        public Task<List<ProductInfo>> GetProductsAsync()
+        {
+            return _dac.GetProductsAsync();
+        }
+    }
+}

--- a/Dac/Dac.csproj
+++ b/Dac/Dac.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>

--- a/Dac/ProductDac.cs
+++ b/Dac/ProductDac.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Info;
+using Newtonsoft.Json.Linq;
+
+namespace Dac
+{
+    public class ProductDac
+    {
+        private readonly string _shopUrl = "https://your-shop-name.myshopify.com"; // TODO: replace
+        private readonly string _accessToken = "YOUR_ACCESS_TOKEN"; // TODO: replace
+
+        public async Task<List<ProductInfo>> GetProductsAsync()
+        {
+            using (var client = new HttpClient())
+            {
+                client.BaseAddress = new System.Uri(_shopUrl);
+                client.DefaultRequestHeaders.Add("X-Shopify-Access-Token", _accessToken);
+
+                var response = await client.GetAsync("/admin/api/2023-07/products.json");
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                var products = new List<ProductInfo>();
+                var obj = JObject.Parse(json);
+                foreach (var item in obj["products"])
+                {
+                    products.Add(new ProductInfo
+                    {
+                        Id = (long)item["id"],
+                        Title = (string)item["title"],
+                        Price = item["variants"]?[0]?["price"] != null ? decimal.Parse((string)item["variants"][0]["price"]) : 0
+                    });
+                }
+                return products;
+            }
+        }
+    }
+}

--- a/Info/Info.csproj
+++ b/Info/Info.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Info/ProductInfo.cs
+++ b/Info/ProductInfo.cs
@@ -1,0 +1,9 @@
+namespace Info
+{
+    public class ProductInfo
+    {
+        public long Id { get; set; }
+        public string Title { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# shopifyApp
+# ShopifyApp
+
+This solution illustrates a simple layered architecture using **.NET Framework 4.7.2**. The projects are:
+
+- **Info**: model classes shared across layers.
+- **Dac**: data access layer that calls Shopify's REST API. Replace the placeholder shop URL and access token in `ProductDac` before running.
+- **Biz**: business layer providing operations that use the data layer.
+- **WebApi**: OWIN self‑hosted ASP.NET Web API exposing endpoints. `GET /api/products` returns Shopify product data.
+
+## Build
+
+Open `ShopifyApp.sln` in Visual Studio 2019 or run:
+
+```bash
+msbuild ShopifyApp.sln
+```
+
+## Run
+
+After building, run the `WebApi` project. The server listens on `http://localhost:9000/`.
+
+```
+GET http://localhost:9000/api/products
+```

--- a/ShopifyApp.sln
+++ b/ShopifyApp.sln
@@ -1,0 +1,36 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Info", "Info\\Info.csproj", "{8FD49FDC-B868-4349-B689-6D3F04AEBE2F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dac", "Dac\\Dac.csproj", "{5B73B53B-DF95-4E0E-95EF-01CF64C3FEDD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Biz", "Biz\\Biz.csproj", "{AB2F745E-137A-4F72-869F-30AFDB2030C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebApi\\WebApi.csproj", "{3D7DEF89-102B-4F4C-88E9-DCF6328DE0AF}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {8FD49FDC-B868-4349-B689-6D3F04AEBE2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {8FD49FDC-B868-4349-B689-6D3F04AEBE2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {8FD49FDC-B868-4349-B689-6D3F04AEBE2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {8FD49FDC-B868-4349-B689-6D3F04AEBE2F}.Release|Any CPU.Build.0 = Release|Any CPU
+        {5B73B53B-DF95-4E0E-95EF-01CF64C3FEDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {5B73B53B-DF95-4E0E-95EF-01CF64C3FEDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {5B73B53B-DF95-4E0E-95EF-01CF64C3FEDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {5B73B53B-DF95-4E0E-95EF-01CF64C3FEDD}.Release|Any CPU.Build.0 = Release|Any CPU
+        {AB2F745E-137A-4F72-869F-30AFDB2030C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {AB2F745E-137A-4F72-869F-30AFDB2030C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {AB2F745E-137A-4F72-869F-30AFDB2030C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {AB2F745E-137A-4F72-869F-30AFDB2030C0}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3D7DEF89-102B-4F4C-88E9-DCF6328DE0AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3D7DEF89-102B-4F4C-88E9-DCF6328DE0AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3D7DEF89-102B-4F4C-88E9-DCF6328DE0AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3D7DEF89-102B-4F4C-88E9-DCF6328DE0AF}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/WebApi/Controllers/ProductController.cs
+++ b/WebApi/Controllers/ProductController.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Biz;
+using Info;
+
+namespace WebApi.Controllers
+{
+    [RoutePrefix("api/products")]
+    public class ProductController : ApiController
+    {
+        private readonly ProductBiz _biz = new ProductBiz();
+
+        [HttpGet, Route("")]
+        public async Task<IHttpActionResult> GetProducts()
+        {
+            List<ProductInfo> products = await _biz.GetProductsAsync();
+            return Ok(products);
+        }
+    }
+}

--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Owin.Hosting;
+
+namespace WebApi
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string baseAddress = "http://localhost:9000/";
+
+            using (WebApp.Start<Startup>(url: baseAddress))
+            {
+                Console.WriteLine("Web API started at " + baseAddress);
+                Console.WriteLine("Press Enter to exit...");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -1,0 +1,21 @@
+using System.Web.Http;
+using Owin;
+
+namespace WebApi
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            HttpConfiguration config = new HttpConfiguration();
+            config.MapHttpAttributeRoutes();
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+
+            app.UseWebApi(config);
+        }
+    }
+}

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <ProjectReference Include="..\Biz\Biz.csproj" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
+    <PackageReference Include="Microsoft.Owin.Host.HttpListener" Version="4.2.2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- remove the old Node.js example
- create Info, Dac and Biz class library projects
- add OWIN WebApi host exposing `GET /api/products`
- call Shopify REST API from the data layer (placeholders for credentials)
- update README with build and run instructions

## Testing
- `msbuild ShopifyApp.sln` *(fails: `msbuild: command not found`)*