### PR TITLE
Replace Node app with C# layered solution

### DIFF
--- a/Biz/Biz.csproj
+++ b/Biz/Biz.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <ProjectReference Include="..\Dac\Dac.csproj" />
+  </ItemGroup>
+</Project>

--- a/Biz/ShopifyBiz.cs
+++ b/Biz/ShopifyBiz.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using ShopifyApp.Dac;
+using ShopifyApp.Info;
+
+namespace ShopifyApp.Biz
+{
+    public class ShopifyBiz
+    {
+        private readonly ShopifyDac _dac = new ShopifyDac();
+
+        public void SyncAll()
+        {
+            var products = _dac.FetchProducts();
+            var orders = _dac.FetchOrders();
+            var customers = _dac.FetchCustomers();
+
+            _dac.SaveProducts(products);
+            _dac.SaveOrders(orders);
+            _dac.SaveCustomers(customers);
+        }
+
+        public IEnumerable<ProductInfo> GetProducts() => _dac.FetchProducts();
+        public IEnumerable<OrderInfo> GetOrders() => _dac.FetchOrders();
+        public IEnumerable<CustomerInfo> GetCustomers() => _dac.FetchCustomers();
+    }
+}

--- a/Dac/Dac.csproj
+++ b/Dac/Dac.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <Reference Include="System.Data" />
+  </ItemGroup>
+</Project>

--- a/Dac/ShopifyDac.cs
+++ b/Dac/ShopifyDac.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Net;
+using Newtonsoft.Json;
+using ShopifyApp.Info;
+
+namespace ShopifyApp.Dac
+{
+    public class ShopifyDac
+    {
+        private readonly string _connectionString = "<SQL SERVER CONNECTION STRING>"; // TODO: replace
+        private readonly string _shopifyBaseUrl = "https://<shop>.myshopify.com";
+        private readonly string _apiKey = "<API KEY>";
+        private readonly string _password = "<PASSWORD>";
+
+        private string GetAuthUrl(string endpoint) => $"{_shopifyBaseUrl}/admin/api/2023-01/{endpoint}.json";
+
+        public List<ProductInfo> FetchProducts()
+        {
+            using (var client = new WebClient())
+            {
+                client.Credentials = new NetworkCredential(_apiKey, _password);
+                var json = client.DownloadString(GetAuthUrl("products"));
+                return JsonConvert.DeserializeObject<ShopifyProductList>(json).Products;
+            }
+        }
+
+        public List<OrderInfo> FetchOrders()
+        {
+            using (var client = new WebClient())
+            {
+                client.Credentials = new NetworkCredential(_apiKey, _password);
+                var json = client.DownloadString(GetAuthUrl("orders"));
+                return JsonConvert.DeserializeObject<ShopifyOrderList>(json).Orders;
+            }
+        }
+
+        public List<CustomerInfo> FetchCustomers()
+        {
+            using (var client = new WebClient())
+            {
+                client.Credentials = new NetworkCredential(_apiKey, _password);
+                var json = client.DownloadString(GetAuthUrl("customers"));
+                return JsonConvert.DeserializeObject<ShopifyCustomerList>(json).Customers;
+            }
+        }
+
+        public void SaveProducts(IEnumerable<ProductInfo> products)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                foreach (var p in products)
+                {
+                    var cmd = new SqlCommand("INSERT INTO Products(Id, Title, Price) VALUES(@Id, @Title, @Price)", conn);
+                    cmd.Parameters.AddWithValue("@Id", p.Id);
+                    cmd.Parameters.AddWithValue("@Title", p.Title);
+                    cmd.Parameters.AddWithValue("@Price", p.Price);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public void SaveOrders(IEnumerable<OrderInfo> orders)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                foreach (var o in orders)
+                {
+                    var cmd = new SqlCommand("INSERT INTO Orders(Id, CreatedAt, TotalPrice) VALUES(@Id, @CreatedAt, @TotalPrice)", conn);
+                    cmd.Parameters.AddWithValue("@Id", o.Id);
+                    cmd.Parameters.AddWithValue("@CreatedAt", o.CreatedAt);
+                    cmd.Parameters.AddWithValue("@TotalPrice", o.TotalPrice);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public void SaveCustomers(IEnumerable<CustomerInfo> customers)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                conn.Open();
+                foreach (var c in customers)
+                {
+                    var cmd = new SqlCommand("INSERT INTO Customers(Id, Email, FirstName, LastName) VALUES(@Id, @Email, @FirstName, @LastName)", conn);
+                    cmd.Parameters.AddWithValue("@Id", c.Id);
+                    cmd.Parameters.AddWithValue("@Email", c.Email);
+                    cmd.Parameters.AddWithValue("@FirstName", c.FirstName);
+                    cmd.Parameters.AddWithValue("@LastName", c.LastName);
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private class ShopifyProductList { public List<ProductInfo> Products { get; set; } }
+        private class ShopifyOrderList { public List<OrderInfo> Orders { get; set; } }
+        private class ShopifyCustomerList { public List<CustomerInfo> Customers { get; set; } }
+    }
+}

--- a/Info/CustomerInfo.cs
+++ b/Info/CustomerInfo.cs
@@ -1,0 +1,10 @@
+namespace ShopifyApp.Info
+{
+    public class CustomerInfo
+    {
+        public long Id { get; set; }
+        public string Email { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/Info/Info.csproj
+++ b/Info/Info.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Info/OrderInfo.cs
+++ b/Info/OrderInfo.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ShopifyApp.Info
+{
+    public class OrderInfo
+    {
+        public long Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public decimal TotalPrice { get; set; }
+    }
+}

--- a/Info/ProductInfo.cs
+++ b/Info/ProductInfo.cs
@@ -1,0 +1,9 @@
+namespace ShopifyApp.Info
+{
+    public class ProductInfo
+    {
+        public long Id { get; set; }
+        public string Title { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# shopifyApp
+# ShopifyApp (.NET Framework 4.7.2)
+
+This sample solution demonstrates a layered architecture for integrating with Shopify and storing the data locally in SQL Server. It contains four projects:
+
+- **Info** – Plain model classes representing products, orders and customers.
+- **Dac** – Data access layer. Contains code that fetches data from Shopify via REST API and saves it to SQL Server tables using ADO.NET.
+- **Biz** – Business layer. Coordinates data synchronization by calling the Dac layer.
+- **WebApi** – Self-hosted Web API (OWIN). Provides endpoints to trigger synchronization and read data.
+
+## Build
+
+1. Install the **.NET Framework 4.7.2 Developer Pack** and MSBuild.
+2. Restore NuGet packages for each project.
+3. Run `msbuild ShopifyApp.sln` to build all projects.
+4. Start the Web API by running the generated executable in the `WebApi` project.
+
+## Notes
+
+- Replace placeholders in `ShopifyDac` with your Shopify credentials and SQL Server connection string.
+- Create `Products`, `Orders`, and `Customers` tables in SQL Server to match the insert statements in `ShopifyDac`.
+- The solution is intended as a minimal sample and does not include full error handling.

--- a/ShopifyApp.sln
+++ b/ShopifyApp.sln
@@ -1,0 +1,16 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1525
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Info", "Info\Info.csproj", "{INFO-PROJ-GUID}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dac", "Dac\Dac.csproj", "{DAC-PROJ-GUID}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Biz", "Biz\Biz.csproj", "{BIZ-PROJ-GUID}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebApi\WebApi.csproj", "{WEBAPI-PROJ-GUID}"
+EndProject
+Global
+EndGlobal
+

--- a/WebApi/Controllers/ShopifyController.cs
+++ b/WebApi/Controllers/ShopifyController.cs
@@ -1,0 +1,39 @@
+using System.Web.Http;
+using ShopifyApp.Biz;
+
+namespace ShopifyApp.WebApi.Controllers
+{
+    public class ShopifyController : ApiController
+    {
+        private readonly ShopifyBiz _biz = new ShopifyBiz();
+
+        [HttpPost]
+        [Route("api/sync")]
+        public IHttpActionResult Sync()
+        {
+            _biz.SyncAll();
+            return Ok("Sync completed");
+        }
+
+        [HttpGet]
+        [Route("api/products")]
+        public IHttpActionResult GetProducts()
+        {
+            return Ok(_biz.GetProducts());
+        }
+
+        [HttpGet]
+        [Route("api/orders")]
+        public IHttpActionResult GetOrders()
+        {
+            return Ok(_biz.GetOrders());
+        }
+
+        [HttpGet]
+        [Route("api/customers")]
+        public IHttpActionResult GetCustomers()
+        {
+            return Ok(_biz.GetCustomers());
+        }
+    }
+}

--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -1,0 +1,18 @@
+using System;
+using Microsoft.Owin.Hosting;
+
+namespace ShopifyApp.WebApi
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            const string baseAddress = "http://localhost:9000/";
+            using (WebApp.Start<Startup>(url: baseAddress))
+            {
+                Console.WriteLine($"Service running at {baseAddress}. Press Enter to stop.");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -1,0 +1,15 @@
+using Owin;
+using System.Web.Http;
+
+namespace ShopifyApp.WebApi
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            var config = new HttpConfiguration();
+            config.MapHttpAttributeRoutes();
+            app.UseWebApi(config);
+        }
+    }
+}

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <ProjectReference Include="..\Biz\Biz.csproj" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- drop Node.js sample
- add C# .NET Framework Info/Dac/Biz/WebApi projects
- implement Shopify API calls and SQL Server saving
- expose sync and read endpoints via self-hosted Web API
- document build instructions

## Testing
- `msbuild ShopifyApp.sln` *(fails: msbuild not installed)*