### PR TITLE
Replace Node.js project with .NET layered solution

### DIFF
--- a/Biz/Biz.csproj
+++ b/Biz/Biz.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <ProjectReference Include="..\Dac\Dac.csproj" />
+  </ItemGroup>
+</Project>

--- a/Biz/ShopifyBiz.cs
+++ b/Biz/ShopifyBiz.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Info.Models;
+using Dac.Repositories;
+
+namespace Biz
+{
+    public class ShopifyBiz
+    {
+        private readonly ShopifyDac _shopify;
+        private readonly SqlServerDac _db;
+
+        public ShopifyBiz(ShopifyDac shopify, SqlServerDac db)
+        {
+            _shopify = shopify;
+            _db = db;
+        }
+
+        public async Task<List<ProductInfo>> SyncProductsAsync()
+        {
+            var products = await _shopify.GetProductsAsync();
+            await _db.SaveProductsAsync(products);
+            return products;
+        }
+
+        // TODO: Sync orders and customers
+    }
+}

--- a/Dac/Dac.csproj
+++ b/Dac/Dac.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>

--- a/Dac/Repositories/ShopifyDac.cs
+++ b/Dac/Repositories/ShopifyDac.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Info.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Dac.Repositories
+{
+    public class ShopifyDac
+    {
+        private readonly string _baseUrl;
+        private readonly string _accessToken;
+
+        public ShopifyDac(string baseUrl, string accessToken)
+        {
+            _baseUrl = baseUrl.TrimEnd('/');
+            _accessToken = accessToken;
+        }
+
+        private HttpClient CreateClient()
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("X-Shopify-Access-Token", _accessToken);
+            return client;
+        }
+
+        public async Task<List<ProductInfo>> GetProductsAsync()
+        {
+            using (var client = CreateClient())
+            {
+                var json = await client.GetStringAsync($"{_baseUrl}/products.json");
+                var products = new List<ProductInfo>();
+                var array = JObject.Parse(json)["products"] as JArray;
+                if (array != null)
+                {
+                    foreach (var item in array)
+                    {
+                        products.Add(new ProductInfo
+                        {
+                            Id = item["id"]?.ToString(),
+                            Title = item["title"]?.ToString(),
+                            Description = item["body_html"]?.ToString(),
+                            Price = decimal.Parse(item["variants"]?[0]? ["price"]?.ToString() ?? "0")
+                        });
+                    }
+                }
+                return products;
+            }
+        }
+
+        // TODO: similar methods for orders and customers
+    }
+}

--- a/Dac/Repositories/SqlServerDac.cs
+++ b/Dac/Repositories/SqlServerDac.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Info.Models;
+
+namespace Dac.Repositories
+{
+    public class SqlServerDac
+    {
+        private readonly string _connectionString;
+
+        public SqlServerDac(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public async Task SaveProductsAsync(IEnumerable<ProductInfo> products)
+        {
+            using (var conn = new SqlConnection(_connectionString))
+            {
+                await conn.OpenAsync();
+                foreach (var p in products)
+                {
+                    var cmd = new SqlCommand("INSERT INTO Products(Id,Title,Description,Price) VALUES(@Id,@Title,@Description,@Price)", conn);
+                    cmd.Parameters.AddWithValue("@Id", p.Id);
+                    cmd.Parameters.AddWithValue("@Title", p.Title);
+                    cmd.Parameters.AddWithValue("@Description", p.Description);
+                    cmd.Parameters.AddWithValue("@Price", p.Price);
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+        }
+
+        // TODO: Save orders and customers
+    }
+}

--- a/Info/Info.csproj
+++ b/Info/Info.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Info/Models/CustomerInfo.cs
+++ b/Info/Models/CustomerInfo.cs
@@ -1,0 +1,9 @@
+namespace Info.Models
+{
+    public class CustomerInfo
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Info/Models/OrderInfo.cs
+++ b/Info/Models/OrderInfo.cs
@@ -1,0 +1,10 @@
+namespace Info.Models
+{
+    public class OrderInfo
+    {
+        public string Id { get; set; }
+        public string CustomerId { get; set; }
+        public decimal Total { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/Info/Models/ProductInfo.cs
+++ b/Info/Models/ProductInfo.cs
@@ -1,0 +1,10 @@
+namespace Info.Models
+{
+    public class ProductInfo
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# shopifyApp
+# ShopifyApp (.NET Framework 4.7.2)
+
+This sample demonstrates a simple layered architecture for integrating with Shopify using C#.
+
+## Projects
+
+- **Info** - Model classes shared across layers.
+- **Dac** - Data access layer handling Shopify API calls and SQL Server operations.
+- **Biz** - Business logic orchestrating synchronization between Shopify and the local database.
+- **WebApi** - Self-hosted Web API using OWIN to expose endpoints.
+
+## Build
+
+Open `ShopifyApp.sln` in Visual Studio 2019 or later and restore NuGet packages. The solution targets **.NET Framework 4.7.2**.
+
+## Usage
+
+Run the WebApi project. It hosts an HTTP service at `http://localhost:9000/` with the following endpoint:
+
+- `POST /api/products/sync` – fetch products from Shopify and store them in SQL Server.
+
+Order and customer APIs are left as TODOs.
+
+Credentials and connection strings should be configured in `Startup.cs` when constructing `ShopifyDac` and `SqlServerDac`.

--- a/ShopifyApp.sln
+++ b/ShopifyApp.sln
@@ -1,0 +1,15 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Info", "Info\Info.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dac", "Dac\Dac.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Biz", "Biz\Biz.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebApi\WebApi.csproj", "{44444444-4444-4444-4444-444444444444}"
+EndProject
+Global
+EndGlobal

--- a/WebApi/Controllers/CustomerController.cs
+++ b/WebApi/Controllers/CustomerController.cs
@@ -1,0 +1,10 @@
+using System.Web.Http;
+
+namespace WebApi.Controllers
+{
+    [RoutePrefix("api/customers")]
+    public class CustomerController : ApiController
+    {
+        // TODO: implement customer sync and retrieval
+    }
+}

--- a/WebApi/Controllers/OrderController.cs
+++ b/WebApi/Controllers/OrderController.cs
@@ -1,0 +1,10 @@
+using System.Web.Http;
+
+namespace WebApi.Controllers
+{
+    [RoutePrefix("api/orders")]
+    public class OrderController : ApiController
+    {
+        // TODO: implement order sync and retrieval
+    }
+}

--- a/WebApi/Controllers/ProductController.cs
+++ b/WebApi/Controllers/ProductController.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Web.Http;
+using Biz;
+using Info.Models;
+
+namespace WebApi.Controllers
+{
+    [RoutePrefix("api/products")]
+    public class ProductController : ApiController
+    {
+        private readonly ShopifyBiz _biz;
+        public ProductController(ShopifyBiz biz)
+        {
+            _biz = biz;
+        }
+
+        [HttpPost, Route("sync")]
+        public async Task<IHttpActionResult> Sync()
+        {
+            List<ProductInfo> products = await _biz.SyncProductsAsync();
+            return Ok(products);
+        }
+    }
+}

--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Web.Http;
+using Microsoft.Owin.Hosting;
+
+namespace WebApi
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string baseAddress = "http://localhost:9000/";
+            using (WebApp.Start<Startup>(url: baseAddress))
+            {
+                Console.WriteLine($"Listening on {baseAddress}. Press Enter to exit...");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/WebApi/SimpleResolver.cs
+++ b/WebApi/SimpleResolver.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Web.Http.Dependencies;
+using Biz;
+
+namespace WebApi
+{
+    public class SimpleResolver : IDependencyResolver
+    {
+        private readonly ShopifyBiz _biz;
+        public SimpleResolver(ShopifyBiz biz)
+        {
+            _biz = biz;
+        }
+        public IDependencyScope BeginScope() => this;
+        public void Dispose() { }
+        public object GetService(Type serviceType)
+        {
+            if (serviceType == typeof(ShopifyBiz))
+                return _biz;
+            return null;
+        }
+        public IEnumerable<object> GetServices(Type serviceType) => new object[0];
+    }
+}

--- a/WebApi/Startup.cs
+++ b/WebApi/Startup.cs
@@ -1,0 +1,36 @@
+using Biz;
+using Dac.Repositories;
+using Microsoft.Owin;
+using Owin;
+using System.Web.Http;
+
+[assembly: OwinStartup(typeof(WebApi.Startup))]
+namespace WebApi
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            HttpConfiguration config = new HttpConfiguration();
+            ConfigureRoutes(config);
+
+            // create biz layer dependencies
+            var shopify = new ShopifyDac("<shop-url>", "<token>");
+            var db = new SqlServerDac("<connection-string>");
+            var biz = new ShopifyBiz(shopify, db);
+            config.DependencyResolver = new SimpleResolver(biz);
+
+            app.UseWebApi(config);
+        }
+
+        private void ConfigureRoutes(HttpConfiguration config)
+        {
+            config.MapHttpAttributeRoutes();
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Info\Info.csproj" />
+    <ProjectReference Include="..\Biz\Biz.csproj" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.9" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- remove Node.js files
- create Info, Dac, Biz, and WebApi C# projects targeting .NET Framework 4.7.2
- add model classes for products, orders, and customers
- implement Shopify data access and SQL Server stubs
- wire up a self-hosted Web API with dependency injection
- document build and usage steps in README

## Testing
- `msbuild ShopifyApp.sln` *(fails: msbuild not installed)*